### PR TITLE
chore: Add github action for deploying

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+name: Deploy project
+on:
+    push:
+        branches:
+            - main
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v3
+
+            - uses: actions/setup-python@v3
+              with:
+                  python-version: "3.9"
+                  cache: "pip"
+
+            - name: Install dependencies
+              run: pip install -r requirements.txt
+
+            - run: databutton deploy
+              env:
+                  DATABUTTON_TOKEN: ${{ secrets.DATABUTTON_TOKEN }}


### PR DESCRIPTION
@tkarper if you could add a secret to this repo with name `DATABUTTON_TOKEN` and the contents is the output of the `refreshToken` in `databutton whoami -r`:
<img width="711" alt="image" src="https://user-images.githubusercontent.com/2552277/184687028-f5d47c63-5755-49c3-8b96-820151e8ece7.png">

Then this repo will autodeploy to databutton on commits so we can all contribute to it 👍 
